### PR TITLE
Added support for surrogate pairs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ language: php
 php:
   # using major version aliases
 
-  # aliased to 5.2.17
-  - 5.2
   # aliased to 5.3.29
   - 5.3
   # aliased to a recent 5.4.x version

--- a/tests/test.php
+++ b/tests/test.php
@@ -133,6 +133,22 @@ class SMSCounterTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expected, $count);
     }
 
+    public function testSurrogateUnicode()
+    {
+        $text = "🎈";
+
+		$count = SMSCounter::count($text);
+
+		$expected = new stdClass();
+		$expected->encoding = SMSCounter::UTF16;
+		$expected->length = 2;
+		$expected->per_message= 70;
+		$expected->remaining = 68;
+		$expected->messages = 1;
+
+		$this->assertEquals($expected, $count);
+    }
+
 	public function testRemoveNonGSMChars(){
 		$text = "no-unicode-remaining";
 


### PR DESCRIPTION
In UTF16, characters above 0xFFFF are stored as four bytes instead of two. This means that they take up two spaces in an SMS message.

With this change, the length of for example emoji is correctly calculated.